### PR TITLE
クリック連打時にワープする問題を修正

### DIFF
--- a/script/main.js
+++ b/script/main.js
@@ -274,7 +274,10 @@ function main(param) {
           let imageD = Math.abs(Math.sqrt(Math.pow(Math.abs(PlayerDatas[ev.player.id].Main_Player.x - NextX),2) + Math.pow(Math.abs(PlayerDatas[ev.player.id].Main_Player.y - NextY),2)));
 
           //移動処理
-          timeline.create(PlayerDatas[ev.player.id].Main_Player).moveTo(NextX, NextY, imageD * 5);
+          if(PlayerDatas[ev.player.id].moveTween){
+            PlayerDatas[ev.player.id].moveTween.cancel();
+          }
+          PlayerDatas[ev.player.id].moveTween = timeline.create(PlayerDatas[ev.player.id].Main_Player).moveTo(NextX, NextY, imageD * 5);
         }
       }
     });


### PR DESCRIPTION
## やったこと
Entityにtween処理が新しく追加された際、以前のtween処理は自動で削除されないらしく、以前の移動処理より先に新しい移動処理が終わった場合、キャラクターがワープするような挙動が発生していた。
（長距離移動のクリック直後に足元付近をクリックすることで再現可能）

これの対策として、新しく移動処理を始める前に、以前の移動処理を中断する処理を追加した。