### PR TITLE
ゲームが落ちる原因がNullなプレイヤー名であることが分かったため、対策を実施

### DIFF
--- a/script/main.js
+++ b/script/main.js
@@ -452,17 +452,7 @@ function main(param) {
 
           let sotugyoY = 0;
           let taigakuY = 0;
-          console.log("before create name list");
           PlayerIds.forEach(Id => {
-            if(PlayerDatas[Id] == null){
-              console.warn(`PlayerDatas[${Id}] is invalid: ${PlayerDatas[Id]}`);
-              return;
-            }
-            if(PlayerDatas[Id].Name == null){
-              console.warn(`PlayerDatas[${Id}].Name is invalid: ${PlayerDatas[Id].Name}`);
-              return;
-            }
-      
             //卒業・退学リスト作成
             if (PlayerDatas[Id].sotuThen == true){
               sotugyolabels.push(user_add(scene,PlayerDatas[Id].Name,sotugyoY));
@@ -473,7 +463,6 @@ function main(param) {
               taigakuY += 60;
             }
           });
-          console.log("after create name list");
         }
       }
 

--- a/script/main.js
+++ b/script/main.js
@@ -119,7 +119,8 @@ function main(param) {
       scene.append(playerImage);
       playerImage.invalidate();
 
-      PlayerDatas[ev.player.id] = {Name:ev.player.name, Main_Player:playerImage, moveX:0, moveY:0, imageD:0, sotuThen:false, destoroyed:false, imageOk:imageOk, imageNg:imageNg};
+      const name = ev.player.name ?? "██████████"; // 名前はnullになることがあるので、その対策としてデフォルト値を設定
+      PlayerDatas[ev.player.id] = {Name:name, Main_Player:playerImage, moveX:0, moveY:0, imageD:0, sotuThen:false, destoroyed:false, imageOk:imageOk, imageNg:imageNg};
 
       playercntLabel.text = String(PlayerIds.length) + "人",
       playercntLabel.invalidate();


### PR DESCRIPTION
戌宮さん枠で複数回ゲームを実施し、プレイヤー名がNullである以外のwarningが出なかったのと、ドキュメント内に名前にNullが入る可能性があることが記載されていたため、一連のエラー落ちの原因を名前がNullであったためと断定し、対策のためのコードを追加しました。また、検証用のコードも削除しています。

具体的には、`g.game.onPlayerInfo`コールバックが呼び出された際に`ev.player.name`にNullが入っていた場合は適当な代替文字列を入れることにしました。
ローカルの検証環境ではNullが入るパターンを再現できませんでしたが、このPRを入れた場合、見た目は以下の様になるはずです。
![image](https://github.com/user-attachments/assets/2e3f129c-1279-46a2-a326-d29fcb199598)

（個人的に黒塗りのアルバムに趣を感じるのでこのようにしていますが、代替テキストはなんでもかまいません。何か要望があればご指摘ください。）
